### PR TITLE
Use DispatcherQueue to interact with account settings at launch

### DIFF
--- a/Natsurainko.FluentLauncher/Models/LaunchArrangement.cs
+++ b/Natsurainko.FluentLauncher/Models/LaunchArrangement.cs
@@ -232,10 +232,13 @@ public partial class LaunchArrangement : ObservableObject
 
                     if (launcher.Authenticator != null)
                     {
-                        _settings.Accounts.Remove(_settings.CurrentAccount);
+                        App.MainWindow.DispatcherQueue.TryEnqueue(() =>
+                        {
+                            _settings.Accounts.Remove(_settings.CurrentAccount);
 
-                        _settings.Accounts.Add(arrangement.LaunchSetting.Account);
-                        _settings.CurrentAccount = arrangement.LaunchSetting.Account;
+                            _settings.Accounts.Add(arrangement.LaunchSetting.Account);
+                            _settings.CurrentAccount = arrangement.LaunchSetting.Account;
+                        });
                     }
 
                     if (!string.IsNullOrEmpty(arrangement.LaunchSetting.GameWindowSetting.WindowTitle))


### PR DESCRIPTION
In `LaunchArrangement.cs`, account settings are changed on a different thread. An exception is caused because the account settings are bound to UI properties, which can only be set on the main thread.