### PR TITLE
Add AccountService for adding/removing/activating accounts and store account data using JSON file

### DIFF
--- a/Natsurainko.FluentLauncher/App.xaml.cs
+++ b/Natsurainko.FluentLauncher/App.xaml.cs
@@ -17,6 +17,8 @@ using Natsurainko.FluentLauncher.Views;
 using System.Text.Json;
 using Natsurainko.FluentLauncher.Services.Accounts;
 using Natsurainko.FluentLauncher.Services.Storage;
+using Natsurainko.FluentLauncher.Services.UI;
+using Natsurainko.FluentLauncher.Services.UI.Messaging;
 
 namespace Natsurainko.FluentLauncher;
 
@@ -89,6 +91,7 @@ public partial class App : Application
         services.AddSingleton<CurseForgeModService>();
         services.AddSingleton<AccountService>();
         services.AddSingleton<LocalStorageService>();
+        services.AddSingleton<MessengerService>();
 
         // Settings service
         services.AddSingleton<SettingsService>();

--- a/Natsurainko.FluentLauncher/App.xaml.cs
+++ b/Natsurainko.FluentLauncher/App.xaml.cs
@@ -16,6 +16,7 @@ using Natsurainko.FluentLauncher.Services.Settings;
 using Natsurainko.FluentLauncher.Views;
 using System.Text.Json;
 using Natsurainko.FluentLauncher.Services.Accounts;
+using Natsurainko.FluentLauncher.Services.Storage;
 
 namespace Natsurainko.FluentLauncher;
 
@@ -87,6 +88,7 @@ public partial class App : Application
         services.AddSingleton<OfficialNewsService>();
         services.AddSingleton<CurseForgeModService>();
         services.AddSingleton<AccountService>();
+        services.AddSingleton<LocalStorageService>();
 
         // Settings service
         services.AddSingleton<SettingsService>();

--- a/Natsurainko.FluentLauncher/App.xaml.cs
+++ b/Natsurainko.FluentLauncher/App.xaml.cs
@@ -68,6 +68,7 @@ public partial class App : Application
 
     protected override void OnLaunched(LaunchActivatedEventArgs args)
     {
+        App.GetService<MessengerService>().SubscribeEvents();
         try
         {
             MainWindow = new MainWindow();

--- a/Natsurainko.FluentLauncher/App.xaml.cs
+++ b/Natsurainko.FluentLauncher/App.xaml.cs
@@ -15,6 +15,7 @@ using AppSettingsManagement.Windows;
 using Natsurainko.FluentLauncher.Services.Settings;
 using Natsurainko.FluentLauncher.Views;
 using System.Text.Json;
+using Natsurainko.FluentLauncher.Services.Accounts;
 
 namespace Natsurainko.FluentLauncher;
 
@@ -85,6 +86,7 @@ public partial class App : Application
         // Services
         services.AddSingleton<OfficialNewsService>();
         services.AddSingleton<CurseForgeModService>();
+        services.AddSingleton<AccountService>();
 
         // Settings service
         services.AddSingleton<SettingsService>();

--- a/Natsurainko.FluentLauncher/Components/FluentCore/GameCore.cs
+++ b/Natsurainko.FluentLauncher/Components/FluentCore/GameCore.cs
@@ -3,6 +3,7 @@ using Natsurainko.FluentCore.Extension.Windows.Service;
 using Natsurainko.FluentCore.Model.Launch;
 using Natsurainko.FluentCore.Module.Launcher;
 using Natsurainko.FluentLauncher.Models;
+using Natsurainko.FluentLauncher.Services.Accounts;
 using Natsurainko.FluentLauncher.Services.Settings;
 using Natsurainko.Toolkits.Text;
 using Natsurainko.Toolkits.Values;
@@ -15,13 +16,15 @@ using Windows.Storage;
 
 namespace Natsurainko.FluentLauncher.Components.FluentCore;
 
-public class GameCore : Natsurainko.FluentCore.Model.Launch.GameCore
+class GameCore : Natsurainko.FluentCore.Model.Launch.GameCore
 {
-    private SettingsService _settings;
+    private readonly SettingsService _settings;
+    private readonly AccountService _accountService;
 
-    public GameCore(SettingsService settings)
+    public GameCore(SettingsService settings, AccountService accountService)
     {
         _settings = settings;
+        _accountService = accountService;
     }
 
     public CoreProfile CoreProfile { get; set; }
@@ -46,7 +49,7 @@ public class GameCore : Natsurainko.FluentCore.Model.Launch.GameCore
     {
         var globalSetting = new LaunchSetting
         {
-            Account = _settings.CurrentAccount,
+            Account = _accountService.ActiveAccount,
             IsDemoUser = _settings.EnableDemoUser,
             EnableIndependencyCore = _settings.EnableIndependencyCore,
             GameWindowSetting = new()

--- a/Natsurainko.FluentLauncher/Components/FluentCore/GameCoreLocator.cs
+++ b/Natsurainko.FluentLauncher/Components/FluentCore/GameCoreLocator.cs
@@ -8,7 +8,7 @@ using System.IO;
 
 namespace Natsurainko.FluentLauncher.Components.FluentCore;
 
-public class GameCoreLocator : IGameCoreLocator<GameCore>
+class GameCoreLocator : IGameCoreLocator<GameCore>
 {
     public DirectoryInfo Root { get; private set; }
 

--- a/Natsurainko.FluentLauncher/Components/FluentCore/GameCoreParser.cs
+++ b/Natsurainko.FluentLauncher/Components/FluentCore/GameCoreParser.cs
@@ -2,6 +2,7 @@
 using Natsurainko.FluentCore.Module.Parser;
 using Natsurainko.FluentCore.Service;
 using Natsurainko.FluentLauncher.Models;
+using Natsurainko.FluentLauncher.Services.Accounts;
 using Natsurainko.FluentLauncher.Services.Settings;
 using Newtonsoft.Json;
 using System;
@@ -11,7 +12,7 @@ using System.Linq;
 
 namespace Natsurainko.FluentLauncher.Components.FluentCore;
 
-public class GameCoreParser : Natsurainko.FluentCore.Module.Parser.GameCoreParser
+class GameCoreParser : Natsurainko.FluentCore.Module.Parser.GameCoreParser
 {
     public GameCoreParser(DirectoryInfo root, IEnumerable<VersionJsonEntity> jsonEntities)
         : base(root, jsonEntities) { }
@@ -24,7 +25,7 @@ public class GameCoreParser : Natsurainko.FluentCore.Module.Parser.GameCoreParse
         {
             try
             {
-                var core = new GameCore(App.GetService<SettingsService>())
+                var core = new GameCore(App.GetService<SettingsService>(), App.GetService<AccountService>())
                 {
                     Id = entity.Id,
                     Type = entity.Type,

--- a/Natsurainko.FluentLauncher/Components/GlobalActivitiesCache.cs
+++ b/Natsurainko.FluentLauncher/Components/GlobalActivitiesCache.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Natsurainko.FluentLauncher.Components;
 
-public static class GlobalActivitiesCache
+static class GlobalActivitiesCache
 {
     public static List<LaunchArrangement> LaunchArrangements { get; private set; } = new List<LaunchArrangement>();
 

--- a/Natsurainko.FluentLauncher/Models/LaunchArrangement.cs
+++ b/Natsurainko.FluentLauncher/Models/LaunchArrangement.cs
@@ -13,6 +13,7 @@ using Natsurainko.FluentCore.Module.Authenticator;
 using Natsurainko.FluentCore.Wrapper;
 using Natsurainko.FluentLauncher.Components;
 using Natsurainko.FluentLauncher.Components.CrossProcess;
+using Natsurainko.FluentLauncher.Services.Accounts;
 using Natsurainko.FluentLauncher.Services.Settings;
 using Natsurainko.FluentLauncher.Utils.Xaml;
 using Natsurainko.Toolkits.Network.Downloader;
@@ -30,9 +31,10 @@ using GameCoreLocator = Natsurainko.FluentLauncher.Components.FluentCore.GameCor
 
 namespace Natsurainko.FluentLauncher.Models;
 
-public partial class LaunchArrangement : ObservableObject
+internal partial class LaunchArrangement : ObservableObject
 {
     private static SettingsService _settings = App.GetService<SettingsService>();
+    private static AccountService _accountService = App.GetService<AccountService>();
 
     public LaunchArrangement(GameCore core)
     {
@@ -234,10 +236,12 @@ public partial class LaunchArrangement : ObservableObject
                     {
                         App.MainWindow.DispatcherQueue.TryEnqueue(() =>
                         {
-                            _settings.Accounts.Remove(_settings.CurrentAccount);
+                            _accountService.Remove(_accountService.ActiveAccount);
 
-                            _settings.Accounts.Add(arrangement.LaunchSetting.Account);
-                            _settings.CurrentAccount = arrangement.LaunchSetting.Account;
+#pragma warning disable CS0612 // Type or member is obsolete
+                            _accountService.AddAccount(arrangement.LaunchSetting.Account);
+#pragma warning restore CS0612 // Type or member is obsolete
+                            _accountService.Activate(arrangement.LaunchSetting.Account);
                         });
                     }
 

--- a/Natsurainko.FluentLauncher/Services/Accounts/AccountService.cs
+++ b/Natsurainko.FluentLauncher/Services/Accounts/AccountService.cs
@@ -42,6 +42,8 @@ class AccountService
 
     public AccountService()
     {
+        LoadData();
+        _accounts.CollectionChanged += (_, e) => SaveData(); // Save the account list when the collection is changed
         Accounts = new ReadOnlyObservableCollection<IAccount>(_accounts);
     }
 
@@ -99,5 +101,22 @@ class AccountService
     public bool AddAccount(AccountType accountType, object param)
     {
         throw new NotImplementedException();
+    }
+
+    /// <summary>
+    /// Loads the account list to Accounts from a JSON file
+    /// </summary>
+    private void LoadData()
+    {
+
+    }
+
+    /// <summary>
+    /// Save the account list to a JSON file
+    /// Called automatically when Accounts is changed
+    /// </summary>
+    private void SaveData()
+    {
+
     }
 }

--- a/Natsurainko.FluentLauncher/Services/Accounts/AccountService.cs
+++ b/Natsurainko.FluentLauncher/Services/Accounts/AccountService.cs
@@ -52,7 +52,16 @@ class AccountService
     {
         _storageService = storageService;
         _settingsService = settingsService;
-        LoadData();
+
+        LoadAccountsList();
+        if (_settingsService.ActiveAccountUuid is Guid uuid)
+        {
+            IAccount activeAccount = _accounts.Where(x => x.Uuid == uuid).FirstOrDefault();
+            if (activeAccount is not null)
+                ActiveAccount = activeAccount;
+            else
+                _settingsService.ActiveAccountUuid = null; // TODO: Prompt the user that there is an error
+        }
 
         _accounts.CollectionChanged += (_, e) => SaveData(); // Save the account list when the collection is changed
         Accounts = new ReadOnlyObservableCollection<IAccount>(_accounts);
@@ -119,7 +128,7 @@ class AccountService
     /// <summary>
     /// Loads the account list to Accounts from a JSON file
     /// </summary>
-    private void LoadData()
+    private void LoadAccountsList()
     {
         // Read settings/accounts.json from local storage service
         string accountJsonPath = _storageService.GetFile(AccountsJsonPath).FullName;

--- a/Natsurainko.FluentLauncher/Services/Accounts/AccountService.cs
+++ b/Natsurainko.FluentLauncher/Services/Accounts/AccountService.cs
@@ -42,6 +42,8 @@ class AccountService
 
     #endregion
 
+    public readonly string AccountsJsonPath = Path.Combine("settings", "accounts.json");
+
     private readonly LocalStorageService _storageService;
 
     public AccountService(LocalStorageService storageService)
@@ -115,8 +117,7 @@ class AccountService
     private void LoadData()
     {
         // Read settings/accounts.json from local storage service
-        string accountJsonPath = Path.Combine("settings", "accounts.json");
-        accountJsonPath = _storageService.GetFile(accountJsonPath).FullName;
+        string accountJsonPath = _storageService.GetFile(AccountsJsonPath).FullName;
         string accountsJson = File.ReadAllText(accountJsonPath);
 
         // Parse accounts.json
@@ -147,6 +148,21 @@ class AccountService
     /// </summary>
     private void SaveData()
     {
+        var jsonArray = new JsonArray();
+        foreach (var item in Accounts)
+        {
+            // Use derived types to store all properties
+            if (item is OfflineAccount offlineAccount)
+                jsonArray.Add(offlineAccount);
+            else if (item is MicrosoftAccount microsoftAccount)
+                jsonArray.Add(microsoftAccount);
+            else if ((item is YggdrasilAccount yggdrasilAccount))
+                jsonArray.Add(yggdrasilAccount);
+        }
 
+        // Save to file
+        string json = jsonArray.ToJsonString();
+        string path = _storageService.GetFile(AccountsJsonPath).FullName;
+        File.WriteAllText(path, json);
     }
 }

--- a/Natsurainko.FluentLauncher/Services/Accounts/AccountService.cs
+++ b/Natsurainko.FluentLauncher/Services/Accounts/AccountService.cs
@@ -12,6 +12,7 @@ using System.ComponentModel;
 using Natsurainko.FluentLauncher.Services.Storage;
 using System.IO;
 using System.Text.Json.Nodes;
+using Natsurainko.FluentLauncher.Services.Settings;
 
 namespace Natsurainko.FluentLauncher.Services.Accounts;
 
@@ -45,10 +46,12 @@ class AccountService
     public readonly string AccountsJsonPath = Path.Combine("settings", "accounts.json");
 
     private readonly LocalStorageService _storageService;
+    private readonly SettingsService _settingsService;
 
-    public AccountService(LocalStorageService storageService)
+    public AccountService(LocalStorageService storageService, SettingsService settingsService)
     {
         _storageService = storageService;
+        _settingsService = settingsService;
         LoadData();
 
         _accounts.CollectionChanged += (_, e) => SaveData(); // Save the account list when the collection is changed
@@ -65,6 +68,7 @@ class AccountService
         if (_accounts.Contains(account) && ActiveAccount != account)
         {
             ActiveAccount = account;
+            _settingsService.ActiveAccountUuid = account.Uuid;
             ActiveAccountChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(ActiveAccount)));
         }
         else
@@ -93,6 +97,7 @@ class AccountService
             else
             {
                 ActiveAccount = null;
+                _settingsService.ActiveAccountUuid = null;
                 ActiveAccountChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(ActiveAccount)));
             }
         }

--- a/Natsurainko.FluentLauncher/Services/Accounts/AccountService.cs
+++ b/Natsurainko.FluentLauncher/Services/Accounts/AccountService.cs
@@ -8,14 +8,13 @@ using System.Text;
 using System.Threading.Tasks;
 using Natsurainko.FluentCore.Model.Auth;
 using System.Collections.Specialized;
+using System.ComponentModel;
 
 namespace Natsurainko.FluentLauncher.Services.Accounts;
 
 class AccountService
 {
-    public ReadOnlyCollection<IAccount> Accounts { get; }
-    public IAccount ActiveAccount { get; private set; }
-
+    public ReadOnlyObservableCollection<IAccount> Accounts { get; }
     private readonly ObservableCollection<IAccount> _accounts = new();
 
     public event NotifyCollectionChangedEventHandler AccountsChanged
@@ -24,13 +23,21 @@ class AccountService
         remove => _accounts.CollectionChanged -= value;
     }
 
+    public IAccount ActiveAccount { get; private set; }
+
+    public event PropertyChangedEventHandler ActiveAccountChanged;
+
+
     public AccountService()
     {
-        
-        Accounts = _accounts.AsReadOnly();
+        Accounts = new ReadOnlyObservableCollection<IAccount>(_accounts);
     }
 
-
+    /// <summary>
+    /// Set an account as the active account
+    /// </summary>
+    /// <param name="account">The account to be activated</param>
+    /// <exception cref="ArgumentException">Thrown when the account provided is not managed by the AccountService</exception>
     public void Activate(IAccount account)
     {
         if (_accounts.Contains(account))
@@ -39,11 +46,22 @@ class AccountService
             throw new ArgumentException($"{account} is not an account managed by AccountService", nameof(account));
     }
 
+    /// <summary>
+    /// Remove an account managed by AccountService
+    /// </summary>
+    /// <param name="account">Account to be removed</param>
+    /// <returns>Returns true if successful</returns>
     public bool Remove(IAccount account)
     {
         return _accounts.Remove(account);
     }
 
+    /// <summary>
+    /// Add an account to the AccountService by authentication
+    /// </summary>
+    /// <param name="accountType">Type of the account to be added</param>
+    /// <param name="param">Authentication parameters</param>
+    /// <returns>Returns true if successful</returns>
     public bool AddAccount(AccountType accountType, object param)
     {
         throw new NotImplementedException();

--- a/Natsurainko.FluentLauncher/Services/Accounts/AccountService.cs
+++ b/Natsurainko.FluentLauncher/Services/Accounts/AccountService.cs
@@ -114,6 +114,12 @@ class AccountService
         return result;
     }
 
+    [Obsolete]
+    public void AddAccount(IAccount account)
+    {
+        _accounts.Add(account);
+    }
+
     /// <summary>
     /// Add an account to the AccountService by authentication
     /// </summary>

--- a/Natsurainko.FluentLauncher/Services/Accounts/AccountService.cs
+++ b/Natsurainko.FluentLauncher/Services/Accounts/AccountService.cs
@@ -74,15 +74,14 @@ class AccountService
     /// <exception cref="ArgumentException">Thrown when the account provided is not managed by the AccountService</exception>
     public void Activate(IAccount account)
     {
-        if (_accounts.Contains(account) && ActiveAccount != account)
+        if (!_accounts.Contains(account))
+            throw new ArgumentException($"{account} is not an account managed by AccountService", nameof(account));
+
+        if (ActiveAccount != account)
         {
             ActiveAccount = account;
             _settingsService.ActiveAccountUuid = account.Uuid;
             ActiveAccountChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(ActiveAccount)));
-        }
-        else
-        {
-            throw new ArgumentException($"{account} is not an account managed by AccountService", nameof(account));
         }
     }
 

--- a/Natsurainko.FluentLauncher/Services/Accounts/AccountService.cs
+++ b/Natsurainko.FluentLauncher/Services/Accounts/AccountService.cs
@@ -1,0 +1,51 @@
+﻿using Natsurainko.FluentCore.Interface;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text.Json;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Natsurainko.FluentCore.Model.Auth;
+using System.Collections.Specialized;
+
+namespace Natsurainko.FluentLauncher.Services.Accounts;
+
+class AccountService
+{
+    public ReadOnlyCollection<IAccount> Accounts { get; }
+    public IAccount ActiveAccount { get; private set; }
+
+    private readonly ObservableCollection<IAccount> _accounts = new();
+
+    public event NotifyCollectionChangedEventHandler AccountsChanged
+    {
+        add => _accounts.CollectionChanged += value;
+        remove => _accounts.CollectionChanged -= value;
+    }
+
+    public AccountService()
+    {
+        
+        Accounts = _accounts.AsReadOnly();
+    }
+
+
+    public void Activate(IAccount account)
+    {
+        if (_accounts.Contains(account))
+            ActiveAccount = account;
+        else
+            throw new ArgumentException($"{account} is not an account managed by AccountService", nameof(account));
+    }
+
+    public bool Remove(IAccount account)
+    {
+        return _accounts.Remove(account);
+    }
+
+    public bool AddAccount(AccountType accountType, object param)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/Natsurainko.FluentLauncher/Services/Settings/SettingsService.cs
+++ b/Natsurainko.FluentLauncher/Services/Settings/SettingsService.cs
@@ -2,6 +2,7 @@
 using AppSettingsManagement.Converters;
 using Natsurainko.FluentCore.Interface;
 using Natsurainko.FluentCore.Model.Auth;
+using Natsurainko.FluentLauncher.Services.Storage;
 using Natsurainko.FluentLauncher.Utils;
 using System;
 using System.Collections.Generic;
@@ -136,13 +137,13 @@ public partial class SettingsService : SettingsContainer
         string accountsJson = appsettings.Values["Accounts"] as string ?? "null";
         JsonNode jsonNode = JsonNode.Parse(accountsJson) ?? new JsonArray();
 
-        string localDataPath = ApplicationData.Current.LocalFolder.Path; // This takes a long time when stepping over in debugging, but looks ok without a breakpoint.
+        string localDataPath = LocalStorageService.LocalFolderPath;
         string accountSettingsDir = Path.Combine(localDataPath, "settings");
         if (!Directory.Exists(accountSettingsDir))
             Directory.CreateDirectory(accountSettingsDir);
 
         string accountSettingsPath = Path.Combine(accountSettingsDir, "accounts.json");
-        File.WriteAllText(accountSettingsPath, jsonNode.ToString());
+        File.WriteAllText(accountSettingsPath, jsonNode.ToString(), Encoding.UTF8);
 
         //appsettings.Values.Remove("Accounts"); // TODO: Uncomment this after testing
 

--- a/Natsurainko.FluentLauncher/Services/Settings/SettingsService.cs
+++ b/Natsurainko.FluentLauncher/Services/Settings/SettingsService.cs
@@ -26,9 +26,9 @@ public partial class SettingsService : SettingsContainer
     public ObservableCollection<string> JavaRuntimes = new();
 
     //[SettingsCollection(typeof(IAccount), "Accounts")]
-    public ObservableCollection<IAccount> Accounts = new(); // TODO: Remove this
+    //public ObservableCollection<IAccount> Accounts = new(); // TODO: Remove this
 
-    [SettingItem(typeof(IAccount), "CurrentAccount", Converter = typeof(AccountToJsonConverter))] // TODO: Remove this
+    //[SettingItem(typeof(IAccount), "CurrentAccount", Converter = typeof(AccountToJsonConverter))] // TODO: Remove this
     [SettingItem(typeof(Guid), "ActiveAccountUuid")]
 
     [SettingItem(typeof(string), "CurrentGameCore", Default = "", Converter = typeof(JsonStringConverter<string>))]

--- a/Natsurainko.FluentLauncher/Services/Settings/SettingsService.cs
+++ b/Natsurainko.FluentLauncher/Services/Settings/SettingsService.cs
@@ -115,7 +115,7 @@ public partial class SettingsService : SettingsContainer
 
     private void Migrate()
     {
-        ApplicationData.Current.LocalSettings.Values["SettingsVersion"] = 0u; // TODO: testing only, to be removed
+        //ApplicationData.Current.LocalSettings.Values["SettingsVersion"] = 0u; // TODO: testing only, to be removed
         if (SettingsVersion == 0u) // Version 0: Before Release 2.1.8.0
         {
             MigrateFrom_2_1_8_0();

--- a/Natsurainko.FluentLauncher/Services/Settings/SettingsService.cs
+++ b/Natsurainko.FluentLauncher/Services/Settings/SettingsService.cs
@@ -25,10 +25,11 @@ public partial class SettingsService : SettingsContainer
     //[SettingsCollection(typeof(IAccount), "Accounts")]
     public ObservableCollection<IAccount> Accounts = new();
 
+    [SettingItem(typeof(IAccount), "CurrentAccount", Converter = typeof(AccountToJsonConverter))]
+
     [SettingItem(typeof(string), "CurrentGameCore", Default = "", Converter = typeof(JsonStringConverter<string>))]
     [SettingItem(typeof(string), "CurrentGameFolder", Default = "", Converter = typeof(JsonStringConverter<string>))]
     [SettingItem(typeof(string), "CurrentJavaRuntime", Default = "", Converter = typeof(JsonStringConverter<string>))]
-    [SettingItem(typeof(IAccount), "CurrentAccount", Converter = typeof(AccountToJsonConverter))]
     [SettingItem(typeof(int), "JavaVirtualMachineMemory", Default = 1024, Converter = typeof(JsonStringConverter<int>))]
     [SettingItem(typeof(bool), "EnableAutoMemory", Default = true, Converter = typeof(JsonStringConverter<bool>))]
     [SettingItem(typeof(bool), "EnableAutoJava", Default = true, Converter = typeof(JsonStringConverter<bool>))]

--- a/Natsurainko.FluentLauncher/Services/Settings/SettingsService.cs
+++ b/Natsurainko.FluentLauncher/Services/Settings/SettingsService.cs
@@ -77,21 +77,21 @@ public partial class SettingsService : SettingsContainer
         };
 
         // Init Accounts
-        string accountsJson = appsettings.Values["Accounts"] as string ?? "null";
-        var jsonNode = JsonNode.Parse(accountsJson);
-        if (jsonNode is not null)
-            foreach (var item in jsonNode.AsArray())
-            {
-                var accountType = (AccountType)item["Type"].GetValue<int>();
-                IAccount account = accountType switch
-                {
-                    AccountType.Offline => item.Deserialize<OfflineAccount>(),
-                    AccountType.Microsoft => item.Deserialize<MicrosoftAccount>(),
-                    AccountType.Yggdrasil => item.Deserialize<YggdrasilAccount>(),
-                    _ => null
-                };
-                Accounts.Add(account);
-            }
+        //string accountsJson = appsettings.Values["Accounts"] as string ?? "null";
+        //var jsonNode = JsonNode.Parse(accountsJson);
+        //if (jsonNode is not null)
+        //    foreach (var item in jsonNode.AsArray())
+        //    {
+        //        var accountType = (AccountType)item["Type"].GetValue<int>();
+        //        IAccount account = accountType switch
+        //        {
+        //            AccountType.Offline => item.Deserialize<OfflineAccount>(),
+        //            AccountType.Microsoft => item.Deserialize<MicrosoftAccount>(),
+        //            AccountType.Yggdrasil => item.Deserialize<YggdrasilAccount>(),
+        //            _ => null
+        //        };
+        //        Accounts.Add(account);
+        //    }
         Accounts.CollectionChanged += (sender, e) =>
         {
             var jsonArray = new JsonArray();
@@ -143,7 +143,7 @@ public partial class SettingsService : SettingsContainer
             Directory.CreateDirectory(accountSettingsDir);
 
         string accountSettingsPath = Path.Combine(accountSettingsDir, "accounts.json");
-        File.WriteAllText(accountSettingsPath, jsonNode.ToString(), Encoding.UTF8);
+        File.WriteAllText(accountSettingsPath, jsonNode.ToString());
 
         //appsettings.Values.Remove("Accounts"); // TODO: Uncomment this after testing
 

--- a/Natsurainko.FluentLauncher/Services/Settings/SettingsService.cs
+++ b/Natsurainko.FluentLauncher/Services/Settings/SettingsService.cs
@@ -28,7 +28,7 @@ public partial class SettingsService : SettingsContainer
     //[SettingsCollection(typeof(IAccount), "Accounts")]
     public ObservableCollection<IAccount> Accounts = new(); // TODO: Remove this
 
-    [SettingItem(typeof(IAccount), "CurrentAccount", Converter = typeof(AccountToJsonConverter))] // TODO: Remove this
+    //[SettingItem(typeof(IAccount), "CurrentAccount", Converter = typeof(AccountToJsonConverter))] // TODO: Remove this
     [SettingItem(typeof(Guid), "ActiveAccountUuid")]
 
     [SettingItem(typeof(string), "CurrentGameCore", Default = "", Converter = typeof(JsonStringConverter<string>))]

--- a/Natsurainko.FluentLauncher/Services/Settings/SettingsService.cs
+++ b/Natsurainko.FluentLauncher/Services/Settings/SettingsService.cs
@@ -92,21 +92,22 @@ public partial class SettingsService : SettingsContainer
         //        };
         //        Accounts.Add(account);
         //    }
-        Accounts.CollectionChanged += (sender, e) =>
-        {
-            var jsonArray = new JsonArray();
-            foreach (var item in Accounts)
-            {
-                if (item is OfflineAccount)
-                    jsonArray.Add((OfflineAccount)item);
-                else if (item is MicrosoftAccount)
-                    jsonArray.Add((MicrosoftAccount)item);
-                else if ((item is YggdrasilAccount))
-                    jsonArray.Add((YggdrasilAccount)item);
-            }
+        //Accounts.CollectionChanged += (sender, e) =>
+        //{
+        //    var jsonArray = new JsonArray();
+        //    foreach (var item in Accounts)
+        //    {
+        //        // Use derived types to store all properties
+        //        if (item is OfflineAccount offlineAccount)
+        //            jsonArray.Add(offlineAccount);
+        //        else if (item is MicrosoftAccount microsoftAccount)
+        //            jsonArray.Add(microsoftAccount);
+        //        else if ((item is YggdrasilAccount yggdrasilAccount))
+        //            jsonArray.Add(yggdrasilAccount);
+        //    }
 
-            appsettings.Values["Accounts"] = jsonArray.ToJsonString();
-        };
+        //    appsettings.Values["Accounts"] = jsonArray.ToJsonString();
+        //};
 
         // Migrate settings data structures from old versions
         Migrate();

--- a/Natsurainko.FluentLauncher/Services/Settings/SettingsService.cs
+++ b/Natsurainko.FluentLauncher/Services/Settings/SettingsService.cs
@@ -28,7 +28,7 @@ public partial class SettingsService : SettingsContainer
     //[SettingsCollection(typeof(IAccount), "Accounts")]
     public ObservableCollection<IAccount> Accounts = new(); // TODO: Remove this
 
-    //[SettingItem(typeof(IAccount), "CurrentAccount", Converter = typeof(AccountToJsonConverter))] // TODO: Remove this
+    [SettingItem(typeof(IAccount), "CurrentAccount", Converter = typeof(AccountToJsonConverter))] // TODO: Remove this
     [SettingItem(typeof(Guid), "ActiveAccountUuid")]
 
     [SettingItem(typeof(string), "CurrentGameCore", Default = "", Converter = typeof(JsonStringConverter<string>))]

--- a/Natsurainko.FluentLauncher/Services/Storage/LocalStorageService.cs
+++ b/Natsurainko.FluentLauncher/Services/Storage/LocalStorageService.cs
@@ -1,0 +1,73 @@
+﻿using Natsurainko.FluentLauncher.Utils;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.Storage;
+
+namespace Natsurainko.FluentLauncher.Services.Storage;
+
+class LocalStorageService
+{
+    /// <summary>
+    /// Full path of the local app data store
+    /// </summary>
+    public static string LocalFolderPath { get; }
+
+    // Consider making LocalFolderPath a non-static member and creating a separate class for non-msix packaged app
+    static LocalStorageService()
+    {
+        if (MsixPackageUtils.IsPackaged)
+            LocalFolderPath = ApplicationData.Current.LocalFolder.Path; // This takes a long time when stepping over in debugging, but looks ok without a breakpoint.
+        else
+            throw new NotSupportedException();
+    }
+
+    /// <summary>
+    /// Determines whether the file at the given path exists in the local app data store
+    /// </summary>
+    /// <param name="path">Path of the file in the local app data store</param>
+    /// <returns>true if path referts to an existing file</returns>
+    public bool HasFile(string path)
+        => File.Exists(Path.Combine(LocalFolderPath, path));
+
+    /// <summary>
+    /// Determines whether the directory at the given path exists in the local app data store
+    /// </summary>
+    /// <param name="path">Path of the directory in the local app data store</param>
+    /// <returns>true if path referts to an existing directory</returns>
+    public bool HasDirectory(string path)
+        => Directory.Exists(Path.Combine(Path.GetDirectoryName(path), path));
+
+    /// <summary>
+    /// Get a file in the local app data store. <br/>
+    /// This does not guarantee that the file exists.
+    /// </summary>
+    /// <param name="path">Path of the file in the local app data folder</param>
+    /// <returns>FileInfo object of the file</returns>
+    public FileInfo GetFile(string path)
+    {
+        string fullPath = Path.Combine(LocalFolderPath, path);
+
+        return new FileInfo(fullPath);
+    }
+
+    /// <summary>
+    /// Get a directory in the local app data store. <br/>
+    /// Creates the directory if not exist.
+    /// </summary>
+    /// <param name="path">Path of the directory in the local app data folder</param>
+    /// <returns>DirectoryInfo object of the directory</returns>
+    public DirectoryInfo GetDirectory(string path)
+    {
+        string fullPath = Path.Combine(LocalFolderPath, path);
+
+        if (!Directory.Exists(fullPath))
+            Directory.CreateDirectory(fullPath);
+
+        return new DirectoryInfo(fullPath);
+    }
+
+}

--- a/Natsurainko.FluentLauncher/Services/UI/Messaging/Messages.cs
+++ b/Natsurainko.FluentLauncher/Services/UI/Messaging/Messages.cs
@@ -1,0 +1,14 @@
+﻿using CommunityToolkit.Mvvm.Messaging.Messages;
+using Natsurainko.FluentCore.Interface;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Natsurainko.FluentLauncher.Services.UI.Messaging;
+
+class ActiveAccountChangedMessage : ValueChangedMessage<IAccount>
+{
+    public ActiveAccountChangedMessage(IAccount value) : base(value) { }
+}

--- a/Natsurainko.FluentLauncher/Services/UI/Messaging/MessengerService.cs
+++ b/Natsurainko.FluentLauncher/Services/UI/Messaging/MessengerService.cs
@@ -19,11 +19,9 @@ class MessengerService
     public MessengerService(AccountService accountService)
     {
         _accountService = accountService;
-
-        SubscribeEvents();
     }
 
-    private void SubscribeEvents()
+    public void SubscribeEvents()
     {
         _accountService.ActiveAccountChanged += AccountService_ActiveAccountChanged;
     }

--- a/Natsurainko.FluentLauncher/Services/UI/Messaging/MessengerService.cs
+++ b/Natsurainko.FluentLauncher/Services/UI/Messaging/MessengerService.cs
@@ -1,0 +1,35 @@
+﻿using CommunityToolkit.Mvvm.Messaging;
+using Natsurainko.FluentLauncher.Services.Accounts;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Natsurainko.FluentLauncher.Services.UI.Messaging;
+
+/// <summary>
+/// A singleton service for managing events subscription of other components and global messaging
+/// </summary>
+class MessengerService
+{
+    private readonly AccountService _accountService;
+
+    public MessengerService(AccountService accountService)
+    {
+        _accountService = accountService;
+
+        SubscribeEvents();
+    }
+
+    private void SubscribeEvents()
+    {
+        _accountService.ActiveAccountChanged += AccountService_ActiveAccountChanged;
+    }
+
+    private void AccountService_ActiveAccountChanged(object sender, PropertyChangedEventArgs e)
+    {
+        WeakReferenceMessenger.Default.Send(new ActiveAccountChangedMessage(_accountService.ActiveAccount));
+    }
+}

--- a/Natsurainko.FluentLauncher/Utils/MsixPackageUtils.cs
+++ b/Natsurainko.FluentLauncher/Utils/MsixPackageUtils.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Natsurainko.FluentLauncher.Utils;
+internal static class MsixPackageUtils
+{
+    public static bool IsPackaged { get; }
+
+    static MsixPackageUtils() 
+    {
+        IsPackaged = isPackaged();
+    }
+
+    private static bool isPackaged()
+    {
+        try
+        {
+            var package = Windows.ApplicationModel.Package.Current;
+            return true;
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
+    }
+}

--- a/Natsurainko.FluentLauncher/ViewModels/Activities/Launch.cs
+++ b/Natsurainko.FluentLauncher/ViewModels/Activities/Launch.cs
@@ -8,7 +8,7 @@ using System.Linq;
 
 namespace Natsurainko.FluentLauncher.ViewModels.Activities;
 
-public partial class LaunchViewModel : ObservableObject
+partial class LaunchViewModel : ObservableObject
 {
     [ObservableProperty]
     private List<LaunchArrangement> launchArrangements = GlobalActivitiesCache.LaunchArrangements;

--- a/Natsurainko.FluentLauncher/ViewModels/Cores/Properties/InformationViewModel.cs
+++ b/Natsurainko.FluentLauncher/ViewModels/Cores/Properties/InformationViewModel.cs
@@ -10,7 +10,7 @@ using System.Linq;
 
 namespace Natsurainko.FluentLauncher.ViewModels.Cores.Properties;
 
-public partial class InformationViewModel : ObservableObject
+partial class InformationViewModel : ObservableObject
 {
     public InformationViewModel(GameCore core)
     {
@@ -33,7 +33,7 @@ public partial class InformationViewModel : ObservableObject
     }
 }
 
-public partial class InformationViewModel
+partial class InformationViewModel
 {
     [ObservableProperty]
     private GameCore core;

--- a/Natsurainko.FluentLauncher/ViewModels/Cores/Properties/LaunchViewModel.cs
+++ b/Natsurainko.FluentLauncher/ViewModels/Cores/Properties/LaunchViewModel.cs
@@ -10,7 +10,7 @@ using GameCore = Natsurainko.FluentLauncher.Components.FluentCore.GameCore;
 
 namespace Natsurainko.FluentLauncher.ViewModels.Cores.Properties;
 
-public partial class LaunchViewModel : ObservableObject
+partial class LaunchViewModel : ObservableObject
 {
     private bool isLoading = true;
 

--- a/Natsurainko.FluentLauncher/ViewModels/Cores/Properties/ModViewModel.cs
+++ b/Natsurainko.FluentLauncher/ViewModels/Cores/Properties/ModViewModel.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace Natsurainko.FluentLauncher.ViewModels.Cores.Properties;
 
-public partial class ModViewModel : ObservableObject
+partial class ModViewModel : ObservableObject
 {
     public ModViewModel(GameCore core)
     {

--- a/Natsurainko.FluentLauncher/ViewModels/Home/HomeViewModel.cs
+++ b/Natsurainko.FluentLauncher/ViewModels/Home/HomeViewModel.cs
@@ -23,7 +23,7 @@ partial class HomeViewModel : ObservableObject
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(AccountTag))]
     [NotifyPropertyChangedFor(nameof(NoAccountTag))]
-    private IAccount currentAccount;
+    private IAccount activeAccount;
 
 
     private readonly SettingsService _settings;
@@ -36,12 +36,12 @@ partial class HomeViewModel : ObservableObject
         _accountService = accountService;
 
         Accounts = accountService.Accounts;
-        CurrentAccount = accountService.ActiveAccount;
+        ActiveAccount = accountService.ActiveAccount;
 
         WeakReferenceMessenger.Default.Register<ActiveAccountChangedMessage>(this, (r, m) =>
         {
             HomeViewModel vm = r as HomeViewModel;
-            vm.CurrentAccount = m.Value;
+            vm.ActiveAccount = m.Value;
         });
 
         if (!string.IsNullOrEmpty(_settings.CurrentGameFolder))
@@ -70,9 +70,9 @@ partial class HomeViewModel : ObservableObject
     [ObservableProperty]
     private string launchButtonTag;
 
-    public Visibility NoAccountTag => CurrentAccount is null ? Visibility.Visible : Visibility.Collapsed;
+    public Visibility NoAccountTag => ActiveAccount is null ? Visibility.Visible : Visibility.Collapsed;
 
-    public Visibility AccountTag => CurrentAccount is null ? Visibility.Collapsed : Visibility.Visible;
+    public Visibility AccountTag => ActiveAccount is null ? Visibility.Collapsed : Visibility.Visible;
 
     [RelayCommand]
     public Task Launch() => Task.Run(() => LaunchArrangement.StartNew(CurrentGameCore));
@@ -82,8 +82,8 @@ partial class HomeViewModel : ObservableObject
 
     private void HomeViewModel_PropertyChanged(object sender, PropertyChangedEventArgs e)
     {
-        if (e.PropertyName == nameof(CurrentAccount))
-            _accountService.Activate(CurrentAccount);
+        if (e.PropertyName == nameof(ActiveAccount))
+            _accountService.Activate(ActiveAccount);
 
         if (e.PropertyName == nameof(CurrentGameCore))
             _settings.CurrentGameCore = CurrentGameCore?.Id;

--- a/Natsurainko.FluentLauncher/ViewModels/OOBE/AccountViewModel.cs
+++ b/Natsurainko.FluentLauncher/ViewModels/OOBE/AccountViewModel.cs
@@ -25,7 +25,7 @@ partial class AccountViewModel : ObservableRecipient, IRecipient<ActiveAccountCh
     public ReadOnlyObservableCollection<IAccount> Accounts { get; init; }
 
     [ObservableProperty]
-    private IAccount currentAccount;
+    private IAccount activeAccount;
 
     private readonly AccountService _accountService;
 
@@ -33,11 +33,11 @@ partial class AccountViewModel : ObservableRecipient, IRecipient<ActiveAccountCh
     {
         _accountService = accountService;
         Accounts = accountService.Accounts;
-        CurrentAccount = accountService.ActiveAccount;
+        ActiveAccount = accountService.ActiveAccount;
 
         WeakReferenceMessenger.Default.Send(new GuideNavigationMessage()
         {
-            CanNext = CurrentAccount is not null,
+            CanNext = ActiveAccount is not null,
             NextPage = typeof(Views.OOBE.GetStartedPage)
         });
         IsActive = true;
@@ -48,11 +48,11 @@ partial class AccountViewModel : ObservableRecipient, IRecipient<ActiveAccountCh
     public void Receive(ActiveAccountChangedMessage message)
     {
         processingActiveAccountChangedMessage = true;
-        CurrentAccount = message.Value;
+        ActiveAccount = message.Value;
         processingActiveAccountChangedMessage = false;
     }
 
-    partial void OnCurrentAccountChanged(IAccount value)
+    partial void OnActiveAccountChanged(IAccount value)
     {
         WeakReferenceMessenger.Default.Send(new GuideNavigationMessage()
         {

--- a/Natsurainko.FluentLauncher/ViewModels/Settings/AccountViewModel.cs
+++ b/Natsurainko.FluentLauncher/ViewModels/Settings/AccountViewModel.cs
@@ -59,6 +59,7 @@ partial class AccountViewModel : SettingsViewModelBase, ISettingsViewModel
         _settingsService = settingsService;
         _accountService = accountService;
         Accounts = accountService.Accounts;
+        CurrentAccount = accountService.ActiveAccount;
         
         WeakReferenceMessenger.Default.Register<ActiveAccountChangedMessage>(this, (r, m) =>
         {
@@ -66,6 +67,12 @@ partial class AccountViewModel : SettingsViewModelBase, ISettingsViewModel
             vm.CurrentAccount = m.Value;
         });
         (this as ISettingsViewModel).InitializeSettings();
+    }
+
+    partial void OnCurrentAccountChanged(IAccount value)
+    {
+        if (value is not null)
+            _accountService.Activate(value);
     }
 
 

--- a/Natsurainko.FluentLauncher/ViewModels/Settings/AccountViewModel.cs
+++ b/Natsurainko.FluentLauncher/ViewModels/Settings/AccountViewModel.cs
@@ -47,9 +47,9 @@ partial class AccountViewModel : SettingsViewModelBase, ISettingsViewModel
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsRemoveVisible))]
-    private IAccount currentAccount;
+    private IAccount activeAccount;
 
-    public bool IsRemoveVisible => CurrentAccount is not null;
+    public bool IsRemoveVisible => ActiveAccount is not null;
 
     private readonly AccountService _accountService;
 
@@ -59,17 +59,17 @@ partial class AccountViewModel : SettingsViewModelBase, ISettingsViewModel
         _settingsService = settingsService;
         _accountService = accountService;
         Accounts = accountService.Accounts;
-        CurrentAccount = accountService.ActiveAccount;
+        ActiveAccount = accountService.ActiveAccount;
         
         WeakReferenceMessenger.Default.Register<ActiveAccountChangedMessage>(this, (r, m) =>
         {
             AccountViewModel vm = r as AccountViewModel;
-            vm.CurrentAccount = m.Value;
+            vm.ActiveAccount = m.Value;
         });
         (this as ISettingsViewModel).InitializeSettings();
     }
 
-    partial void OnCurrentAccountChanged(IAccount value)
+    partial void OnActiveAccountChanged(IAccount value)
     {
         if (value is not null)
             _accountService.Activate(value);
@@ -79,7 +79,7 @@ partial class AccountViewModel : SettingsViewModelBase, ISettingsViewModel
     [RelayCommand]
     public void Remove()
     {
-        _accountService.Remove(CurrentAccount);
+        _accountService.Remove(ActiveAccount);
     }
 
     [RelayCommand]
@@ -103,37 +103,37 @@ partial class AccountViewModel : SettingsViewModelBase, ISettingsViewModel
         {
             IAuthenticator authenticator = default;
             IAccount refreshedAccount = default;
-            if (CurrentAccount.Type.Equals(AccountType.Microsoft))
+            if (ActiveAccount.Type.Equals(AccountType.Microsoft))
             {
-                var account = (MicrosoftAccount)CurrentAccount;
+                var account = (MicrosoftAccount)ActiveAccount;
                 authenticator = new MicrosoftAuthenticator(
                     account.RefreshToken, 
                     "0844e754-1d2e-4861-8e2b-18059609badb", 
                     "https://login.live.com/oauth20_desktop.srf",
                     AuthenticatorMethod.Refresh);
             }
-            else if (CurrentAccount.Type.Equals(AccountType.Yggdrasil))
+            else if (ActiveAccount.Type.Equals(AccountType.Yggdrasil))
             {
-                var account = (YggdrasilAccount)CurrentAccount;
+                var account = (YggdrasilAccount)ActiveAccount;
                 authenticator = new YggdrasilAuthenticator(
                     AuthenticatorMethod.Refresh,
                     account.AccessToken,
                     account.ClientToken,
                     yggdrasilServerUrl: account.YggdrasilServerUrl);
             }
-            else if (CurrentAccount.Type.Equals(AccountType.Offline))
-                authenticator = new OfflineAuthenticator(CurrentAccount.Name, CurrentAccount.Uuid);
+            else if (ActiveAccount.Type.Equals(AccountType.Offline))
+                authenticator = new OfflineAuthenticator(ActiveAccount.Name, ActiveAccount.Uuid);
 
             refreshedAccount = await authenticator.AuthenticateAsync();
 
             App.MainWindow.DispatcherQueue.TryEnqueue(() =>
             {
-                _accountService.Remove(CurrentAccount);
+                _accountService.Remove(ActiveAccount);
 
 #pragma warning disable CS0612 // Type or member is obsolete
                 _accountService.AddAccount(refreshedAccount);
 #pragma warning restore CS0612 // Type or member is obsolete
-                CurrentAccount = refreshedAccount;
+                ActiveAccount = refreshedAccount;
             });
 
             MessageService.ShowSuccess("Successfully refreshed Account", $"Welcome back, {refreshedAccount.Name}");
@@ -149,7 +149,7 @@ partial class AccountViewModel : SettingsViewModelBase, ISettingsViewModel
 #pragma warning disable CS0612 // Type or member is obsolete
         _accountService.AddAccount(account);
 #pragma warning restore CS0612 // Type or member is obsolete
-        CurrentAccount = account;
+        ActiveAccount = account;
 
         MessageService.ShowSuccess($"Add {account.Type} Account Successfully", $"Welcome back, {account.Name}");
     });

--- a/Natsurainko.FluentLauncher/Views/Home/HomePage.xaml
+++ b/Natsurainko.FluentLauncher/Views/Home/HomePage.xaml
@@ -38,12 +38,12 @@
                         VerticalAlignment="Center"
                         FontSize="16"
                         FontWeight="SemiBold"
-                        Text="{Binding CurrentAccount.Name}" />
+                        Text="{Binding ActiveAccount.Name}" />
                     <TextBlock
                         Margin="10,0,0,0"
                         VerticalAlignment="Center"
                         Foreground="{ThemeResource ApplicationSecondaryForegroundThemeBrush}">
-                        <Run Text="{Binding CurrentAccount.Type}" />
+                        <Run Text="{Binding ActiveAccount.Type}" />
                         <Run x:Uid="Home_Account" Text="Account" />
                     </TextBlock>
                 </StackPanel>
@@ -53,7 +53,7 @@
                     <ListView
                         Margin="-15,-13,-15.5,-15"
                         ItemsSource="{Binding Accounts}"
-                        SelectedItem="{Binding CurrentAccount, Mode=TwoWay}">
+                        SelectedItem="{Binding ActiveAccount, Mode=TwoWay}">
                         <ListView.ItemTemplate>
                             <DataTemplate>
                                 <TextBlock TextTrimming="CharacterEllipsis">

--- a/Natsurainko.FluentLauncher/Views/OOBE/AccountPage.xaml
+++ b/Natsurainko.FluentLauncher/Views/OOBE/AccountPage.xaml
@@ -57,7 +57,7 @@
                             <ComboBox
                                 HorizontalAlignment="Stretch"
                                 ItemsSource="{Binding Accounts}"
-                                SelectedItem="{Binding CurrentAccount, Mode=TwoWay}">
+                                SelectedItem="{Binding ActiveAccount, Mode=TwoWay}">
                                 <ComboBox.ItemTemplate>
                                     <DataTemplate>
                                         <TextBlock TextTrimming="CharacterEllipsis">

--- a/Natsurainko.FluentLauncher/Views/Settings/AccountPage.xaml
+++ b/Natsurainko.FluentLauncher/Views/Settings/AccountPage.xaml
@@ -41,7 +41,7 @@
                                 Height="60"
                                 MinWidth="180"
                                 ItemsSource="{Binding Accounts}"
-                                SelectedItem="{Binding CurrentAccount, Mode=TwoWay}">
+                                SelectedItem="{Binding ActiveAccount, Mode=TwoWay}">
                                 <i:Interaction.Behaviors>
                                     <behaviors:SetComboBoxWidthFromItemsBehavior SetWidthFromItems="True" />
                                     <behaviors:SettingsCardContentMaxWidthBehavior AscendentType="Grid" AutoMaxWidth="True" />
@@ -117,18 +117,18 @@
                                         <Flyout Placement="BottomEdgeAlignedRight">
                                             <RichTextBlock TextTrimming="CharacterEllipsis">
                                                 <Paragraph>
-                                                    <Run FontWeight="SemiBold" Text="{Binding CurrentAccount.Name}" />
+                                                    <Run FontWeight="SemiBold" Text="{Binding ActiveAccount.Name}" />
                                                     <Run>,</Run>
-                                                    <Run Foreground="{ThemeResource ApplicationSecondaryForegroundThemeBrush}" Text="{Binding CurrentAccount.Type}" />
+                                                    <Run Foreground="{ThemeResource ApplicationSecondaryForegroundThemeBrush}" Text="{Binding ActiveAccount.Type}" />
                                                 </Paragraph>
                                                 <Paragraph>
                                                     <Run Foreground="{ThemeResource ApplicationSecondaryForegroundThemeBrush}">Uuid:</Run>
-                                                    <Run Text="{Binding CurrentAccount.Uuid}" />
+                                                    <Run Text="{Binding ActiveAccount.Uuid}" />
                                                 </Paragraph>
                                                 <!--
                                                 <Paragraph>
                                                     <Run Foreground="{ThemeResource ApplicationSecondaryForegroundThemeBrush}">Yggdrasil Server:</Run>
-                                                    <Run Text="{Binding CurrentAccount.YggdrasilServerUrl}" />
+                                                    <Run Text="{Binding ActiveAccount.YggdrasilServerUrl}" />
                                                 </Paragraph>
                                                 -->
                                             </RichTextBlock>

--- a/Natsurainko.FluentLauncher/Views/Settings/AccountPage.xaml.cs
+++ b/Natsurainko.FluentLauncher/Views/Settings/AccountPage.xaml.cs
@@ -8,7 +8,7 @@ namespace Natsurainko.FluentLauncher.Views.Settings;
 public sealed partial class AccountPage : Page
 {
     public bool RemoveBool = false;
-    public Visibility RemoveVisible => (DataContext as AccountViewModel).CurrentAccount is null ? Visibility.Collapsed : Visibility.Visible;
+    public Visibility RemoveVisible => (DataContext as AccountViewModel).ActiveAccount is null ? Visibility.Collapsed : Visibility.Visible;
 
     public AccountPage()
     {


### PR DESCRIPTION
- Consolidate all logic for managing accounts into one class
- Fix #137
- Store account data in settings/accounts.json in local data storage
- Rename `CurrentAccount` to `ActiveAccount`
- In the settings service, only the UUID of the active account is stored. This can be used to find the account from accounts.json

Future work: build an AuthenticationService for adding accounts