### PR TITLE
Improve language selection experience

### DIFF
--- a/Natsurainko.FluentLauncher/App.xaml
+++ b/Natsurainko.FluentLauncher/App.xaml
@@ -81,6 +81,7 @@
 
             <converters:ModInfoConverter x:Key="ModInfoConverter" />
             <converters:SaveInfoConverter x:Key="SaveInfoConverter" />
+            <converters:LanguageCodeToLanguageInfoConverter x:Key="LanguageInfoConverter" />
 
             <converters:InvertBoolConverter x:Key="InvertBoolConverter" />
             <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />

--- a/Natsurainko.FluentLauncher/App.xaml
+++ b/Natsurainko.FluentLauncher/App.xaml
@@ -10,6 +10,7 @@
                 <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
                 <ResourceDictionary Source="Dictionaries/NotifyStyleDictionary" />
                 <ResourceDictionary Source="Dictionaries/TaskViewStyleDictionary" />
+                <ResourceDictionary Source="/UserControls/NoScrollingComboBox.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <ResourceDictionary.ThemeDictionaries>
                 <ResourceDictionary x:Key="Light">

--- a/Natsurainko.FluentLauncher/Models/LanguageInfo.cs
+++ b/Natsurainko.FluentLauncher/Models/LanguageInfo.cs
@@ -1,0 +1,9 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Natsurainko.FluentLauncher.Models;
+
+record struct LanguageInfo(string LanguageCode, string DisplayName);

--- a/Natsurainko.FluentLauncher/Services/Settings/SettingsService.cs
+++ b/Natsurainko.FluentLauncher/Services/Settings/SettingsService.cs
@@ -97,7 +97,7 @@ public partial class SettingsService : SettingsContainer
 
     #endregion
 
-    [SettingItem(Default = "en-US, English", Converter = typeof(JsonStringConverter<string>))] // TODO: remove default value; set to system language if null
+    [SettingItem(Default = "en-US", Converter = typeof(JsonStringConverter<string>))] // TODO: remove default value; set to system language if null
     public partial string CurrentLanguage { get; set; }
 
     #region Appearance Theme Settings

--- a/Natsurainko.FluentLauncher/UserControls/NoScrollingComboBox.cs
+++ b/Natsurainko.FluentLauncher/UserControls/NoScrollingComboBox.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Natsurainko.FluentLauncher.UserControls;
+
+class NoScrollingComboBox : ComboBox
+{
+    protected override void OnPointerWheelChanged(PointerRoutedEventArgs e)
+    {
+        // Disable changing option by scrolling
+    }
+}

--- a/Natsurainko.FluentLauncher/UserControls/NoScrollingComboBox.xaml
+++ b/Natsurainko.FluentLauncher/UserControls/NoScrollingComboBox.xaml
@@ -1,0 +1,10 @@
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Natsurainko.FluentLauncher.UserControls">
+    <ResourceDictionary.MergedDictionaries>
+        <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
+    </ResourceDictionary.MergedDictionaries>
+
+    <Style BasedOn="{StaticResource DefaultComboBoxStyle}" TargetType="local:NoScrollingComboBox" />
+</ResourceDictionary>

--- a/Natsurainko.FluentLauncher/Utils/LocalizedStrings.cs
+++ b/Natsurainko.FluentLauncher/Utils/LocalizedStrings.cs
@@ -1,5 +1,6 @@
 ﻿using FluentLauncher.Infra.LocalizedStrings;
 using Microsoft.Windows.Globalization;
+using Natsurainko.FluentLauncher.Models;
 using Natsurainko.FluentLauncher.Services.Settings;
 using System;
 using System.Collections.Generic;
@@ -13,12 +14,12 @@ namespace Natsurainko.FluentLauncher.Utils;
 [GeneratedLocalizedStrings]
 static partial class LocalizedStrings
 {
-    public static List<string> SupportedLanguages = [
-        "en-US, English",
-        "ru-RU, Русский",
-        "uk-UA, Український",
-        "zh-Hans, 简体中文",
-        "zh-Hant, 繁體中文"
+    public static List<LanguageInfo> SupportedLanguages = [
+        new LanguageInfo("en-US", "English"),
+        new LanguageInfo("ru-RU", "Русский"),
+        new LanguageInfo("uk-UA", "Український"),
+        new LanguageInfo("zh-Hans", "简体中文"),
+        new LanguageInfo("zh-Hant", "繁體中文")
     ];
 
     /// <summary>

--- a/Natsurainko.FluentLauncher/ViewModels/Common/TaskViewModel.cs
+++ b/Natsurainko.FluentLauncher/ViewModels/Common/TaskViewModel.cs
@@ -472,7 +472,7 @@ internal partial class InstallInstanceTaskViewModel : TaskViewModel
         //}
 
         App.GetService<NotificationService>().NotifyException(
-            "_InstallInstanceThrowException",
+            LocalizedStrings.Notifications__InstallInstanceThrowException,
             Exception,
             errorDescriptionKey);
     }

--- a/Natsurainko.FluentLauncher/ViewModels/OOBE/OOBEViewModel.cs
+++ b/Natsurainko.FluentLauncher/ViewModels/OOBE/OOBEViewModel.cs
@@ -5,6 +5,7 @@ using FluentLauncher.Infra.UI.Dialogs;
 using FluentLauncher.Infra.UI.Navigation;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.Win32;
+using Natsurainko.FluentLauncher.Models;
 using Natsurainko.FluentLauncher.Services.Accounts;
 using Natsurainko.FluentLauncher.Services.Launch;
 using Natsurainko.FluentLauncher.Services.Settings;
@@ -100,7 +101,7 @@ internal partial class OOBEViewModel : ObservableObject, INavigationAware, ISett
     bool CanNext() => CurrentPageIndex switch
     {
         // Language page
-        0 => LocalizedStrings.SupportedLanguages.Contains(CurrentLanguage),
+        0 => LocalizedStrings.SupportedLanguages.Select(lang => lang.LanguageCode).Contains(CurrentLanguage),
         // Minecraft folder page
         1 => !string.IsNullOrEmpty(ActiveMinecraftFolder),
         // Java page
@@ -150,8 +151,6 @@ internal partial class OOBEViewModel : ObservableObject, INavigationAware, ISett
     [BindToSetting(Path = nameof(SettingsService.CurrentLanguage))]
     public partial string CurrentLanguage { get; set; }
 
-    public List<string> Languages { get; } = LocalizedStrings.SupportedLanguages;
-
     public string Version => App.Version.GetVersionString();
 
     public string Channel => App.AppChannel.ToUpper();
@@ -164,7 +163,7 @@ internal partial class OOBEViewModel : ObservableObject, INavigationAware, ISett
 
     partial void OnCurrentLanguageChanged(string oldValue, string newValue)
     {
-        if (LocalizedStrings.SupportedLanguages.Contains(CurrentLanguage) && oldValue is not null) // oldValue is null at startup
+        if (oldValue is not null) // oldValue is null at startup
             LocalizedStrings.ApplyLanguage(CurrentLanguage);
     }
 

--- a/Natsurainko.FluentLauncher/ViewModels/Settings/DefaultViewModel.cs
+++ b/Natsurainko.FluentLauncher/ViewModels/Settings/DefaultViewModel.cs
@@ -2,11 +2,13 @@
 using CommunityToolkit.Mvvm.Input;
 using FluentLauncher.Infra.Settings.Mvvm;
 using FluentLauncher.Infra.UI.Navigation;
+using Natsurainko.FluentLauncher.Models;
 using Natsurainko.FluentLauncher.Services.Settings;
 using Natsurainko.FluentLauncher.Utils;
 using Natsurainko.FluentLauncher.Utils.Extensions;
 using Natsurainko.FluentLauncher.ViewModels.Common;
 using System.Collections.Generic;
+using System.Linq;
 
 #nullable disable
 namespace Natsurainko.FluentLauncher.ViewModels.Settings;
@@ -16,8 +18,6 @@ internal partial class DefaultViewModel : SettingsViewModelBase, ISettingsViewMo
     [SettingsProvider]
     private readonly SettingsService _settingsService;
     private readonly INavigationService _navigationService;
-
-    public List<string> Languages { get; } = LocalizedStrings.SupportedLanguages;
 
     public DefaultViewModel(SettingsService settingsService, INavigationService navigationService)
     {
@@ -45,12 +45,10 @@ internal partial class DefaultViewModel : SettingsViewModelBase, ISettingsViewMo
 
     partial void OnCurrentLanguageChanged(string oldValue, string newValue)
     {
-        if (Languages.Contains(CurrentLanguage) && oldValue is not null) // oldValue is null at startup
+        if (oldValue is not null) // oldValue is null at startup
             LocalizedStrings.ApplyLanguage(CurrentLanguage);
     }
 
     [RelayCommand]
     void CardClick(string tag) => _navigationService.NavigateTo(tag);
-
-
 }

--- a/Natsurainko.FluentLauncher/Views/MainWindow.xaml.cs
+++ b/Natsurainko.FluentLauncher/Views/MainWindow.xaml.cs
@@ -35,9 +35,6 @@ public sealed partial class MainWindow : WindowEx, INavigationProvider
         _notificationService = notificationService;
         _navigationService = navigationService;
 
-        if (string.IsNullOrEmpty(ApplicationLanguages.PrimaryLanguageOverride))
-            LocalizedStrings.ApplyLanguage(_settingsService.CurrentLanguage);
-
         App.MainWindow = this;
 
         App.GetService<AppearanceService>().RegisterWindow(this);

--- a/Natsurainko.FluentLauncher/Views/OOBE/LanguagePage.xaml
+++ b/Natsurainko.FluentLauncher/Views/OOBE/LanguagePage.xaml
@@ -2,8 +2,11 @@
     x:Class="Natsurainko.FluentLauncher.Views.OOBE.LanguagePage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:CommunityToolkit.WinUI.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:models="using:Natsurainko.FluentLauncher.Models"
+    xmlns:utils="using:Natsurainko.FluentLauncher.Utils"
     xmlns:vm="using:Natsurainko.FluentLauncher.ViewModels.OOBE"
     d:DataContext="{d:DesignInstance vm:OOBEViewModel}"
     mc:Ignorable="d">
@@ -89,8 +92,25 @@
 
             <ComboBox
                 Grid.Row="3"
-                ItemsSource="{x:Bind VM.Languages}"
-                SelectedItem="{x:Bind VM.CurrentLanguage, Mode=TwoWay}" />
+                ItemsSource="{x:Bind utils:LocalizedStrings.SupportedLanguages}"
+                SelectedItem="{x:Bind VM.CurrentLanguage, Mode=TwoWay, Converter={StaticResource LanguageInfoConverter}}">
+                <ComboBox.ItemTemplate>
+                    <DataTemplate x:DataType="models:LanguageInfo">
+                        <controls:DockPanel>
+                            <TextBlock
+                                Margin="0,0,8,0"
+                                HorizontalAlignment="Left"
+                                controls:DockPanel.Dock="Left"
+                                Text="{x:Bind DisplayName}" />
+                            <TextBlock
+                                HorizontalAlignment="Right"
+                                controls:DockPanel.Dock="Right"
+                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                Text="{x:Bind LanguageCode}" />
+                        </controls:DockPanel>
+                    </DataTemplate>
+                </ComboBox.ItemTemplate>
+            </ComboBox>
         </Grid>
     </Grid>
 </Page>

--- a/Natsurainko.FluentLauncher/Views/OOBE/LanguagePage.xaml
+++ b/Natsurainko.FluentLauncher/Views/OOBE/LanguagePage.xaml
@@ -2,8 +2,10 @@
     x:Class="Natsurainko.FluentLauncher.Views.OOBE.LanguagePage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:behaviors="using:Natsurainko.FluentLauncher.XamlHelpers.Behaviors"
     xmlns:controls="using:CommunityToolkit.WinUI.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:i="using:Microsoft.Xaml.Interactivity"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:models="using:Natsurainko.FluentLauncher.Models"
     xmlns:utils="using:Natsurainko.FluentLauncher.Utils"
@@ -94,6 +96,9 @@
                 Grid.Row="3"
                 ItemsSource="{x:Bind utils:LocalizedStrings.SupportedLanguages}"
                 SelectedItem="{x:Bind VM.CurrentLanguage, Mode=TwoWay, Converter={StaticResource LanguageInfoConverter}}">
+                <i:Interaction.Behaviors>
+                    <behaviors:SetComboBoxWidthFromItemsBehavior SetWidthFromItems="True" />
+                </i:Interaction.Behaviors>
                 <ComboBox.ItemTemplate>
                     <DataTemplate x:DataType="models:LanguageInfo">
                         <controls:DockPanel>

--- a/Natsurainko.FluentLauncher/Views/OOBE/LanguagePage.xaml
+++ b/Natsurainko.FluentLauncher/Views/OOBE/LanguagePage.xaml
@@ -8,6 +8,7 @@
     xmlns:i="using:Microsoft.Xaml.Interactivity"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:models="using:Natsurainko.FluentLauncher.Models"
+    xmlns:mycontrols="using:Natsurainko.FluentLauncher.UserControls"
     xmlns:utils="using:Natsurainko.FluentLauncher.Utils"
     xmlns:vm="using:Natsurainko.FluentLauncher.ViewModels.OOBE"
     d:DataContext="{d:DesignInstance vm:OOBEViewModel}"
@@ -92,14 +93,14 @@
                 Text="Please choose your language before we start setting up Fluent Launcher."
                 TextWrapping="WrapWholeWords" />
 
-            <ComboBox
+            <mycontrols:NoScrollingComboBox
                 Grid.Row="3"
                 ItemsSource="{x:Bind utils:LocalizedStrings.SupportedLanguages}"
                 SelectedItem="{x:Bind VM.CurrentLanguage, Mode=TwoWay, Converter={StaticResource LanguageInfoConverter}}">
                 <i:Interaction.Behaviors>
                     <behaviors:SetComboBoxWidthFromItemsBehavior SetWidthFromItems="True" />
                 </i:Interaction.Behaviors>
-                <ComboBox.ItemTemplate>
+                <mycontrols:NoScrollingComboBox.ItemTemplate>
                     <DataTemplate x:DataType="models:LanguageInfo">
                         <controls:DockPanel>
                             <TextBlock
@@ -114,8 +115,8 @@
                                 Text="{x:Bind LanguageCode}" />
                         </controls:DockPanel>
                     </DataTemplate>
-                </ComboBox.ItemTemplate>
-            </ComboBox>
+                </mycontrols:NoScrollingComboBox.ItemTemplate>
+            </mycontrols:NoScrollingComboBox>
         </Grid>
     </Grid>
 </Page>

--- a/Natsurainko.FluentLauncher/Views/Settings/DefaultPage.xaml
+++ b/Natsurainko.FluentLauncher/Views/Settings/DefaultPage.xaml
@@ -8,6 +8,7 @@
     xmlns:i="using:Microsoft.Xaml.Interactivity"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:models="using:Natsurainko.FluentLauncher.Models"
+    xmlns:mycontrols="using:Natsurainko.FluentLauncher.UserControls"
     xmlns:utils="using:Natsurainko.FluentLauncher.Utils"
     xmlns:xh="using:Natsurainko.FluentLauncher.XamlHelpers"
     mc:Ignorable="d">
@@ -68,12 +69,12 @@
                     x:Uid="Settings_DefaultPage_Card5"
                     Header="Language Settings"
                     HeaderIcon="{xh:FontIcon Glyph=&#xf2b7;}">
-                    <ComboBox ItemsSource="{x:Bind utils:LocalizedStrings.SupportedLanguages}" SelectedItem="{x:Bind VM.CurrentLanguage, Mode=TwoWay, Converter={StaticResource LanguageInfoConverter}}">
+                    <mycontrols:NoScrollingComboBox ItemsSource="{x:Bind utils:LocalizedStrings.SupportedLanguages}" SelectedItem="{x:Bind VM.CurrentLanguage, Mode=TwoWay, Converter={StaticResource LanguageInfoConverter}}">
                         <i:Interaction.Behaviors>
                             <behaviors:SetComboBoxWidthFromItemsBehavior SetWidthFromItems="True" />
                             <behaviors:SettingsCardContentMaxWidthBehavior AscendentType="Grid" AutoMaxWidth="True" />
                         </i:Interaction.Behaviors>
-                        <ComboBox.ItemTemplate>
+                        <mycontrols:NoScrollingComboBox.ItemTemplate>
                             <DataTemplate x:DataType="models:LanguageInfo">
                                 <controls:DockPanel>
                                     <TextBlock
@@ -88,8 +89,8 @@
                                         Text="{x:Bind LanguageCode}" />
                                 </controls:DockPanel>
                             </DataTemplate>
-                        </ComboBox.ItemTemplate>
-                    </ComboBox>
+                        </mycontrols:NoScrollingComboBox.ItemTemplate>
+                    </mycontrols:NoScrollingComboBox>
                 </controls:SettingsCard>
 
                 <TextBlock

--- a/Natsurainko.FluentLauncher/Views/Settings/DefaultPage.xaml
+++ b/Natsurainko.FluentLauncher/Views/Settings/DefaultPage.xaml
@@ -7,6 +7,8 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:i="using:Microsoft.Xaml.Interactivity"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:models="using:Natsurainko.FluentLauncher.Models"
+    xmlns:utils="using:Natsurainko.FluentLauncher.Utils"
     xmlns:xh="using:Natsurainko.FluentLauncher.XamlHelpers"
     mc:Ignorable="d">
 
@@ -66,11 +68,27 @@
                     x:Uid="Settings_DefaultPage_Card5"
                     Header="Language Settings"
                     HeaderIcon="{xh:FontIcon Glyph=&#xf2b7;}">
-                    <ComboBox ItemsSource="{x:Bind VM.Languages, Mode=OneWay}" SelectedItem="{x:Bind VM.CurrentLanguage, Mode=TwoWay}">
+                    <ComboBox ItemsSource="{x:Bind utils:LocalizedStrings.SupportedLanguages}" SelectedItem="{x:Bind VM.CurrentLanguage, Mode=TwoWay, Converter={StaticResource LanguageInfoConverter}}">
                         <i:Interaction.Behaviors>
                             <behaviors:SetComboBoxWidthFromItemsBehavior SetWidthFromItems="True" />
                             <behaviors:SettingsCardContentMaxWidthBehavior AscendentType="Grid" AutoMaxWidth="True" />
                         </i:Interaction.Behaviors>
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate x:DataType="models:LanguageInfo">
+                                <controls:DockPanel>
+                                    <TextBlock
+                                        Margin="0,0,8,0"
+                                        HorizontalAlignment="Left"
+                                        controls:DockPanel.Dock="Left"
+                                        Text="{x:Bind DisplayName}" />
+                                    <TextBlock
+                                        HorizontalAlignment="Right"
+                                        controls:DockPanel.Dock="Right"
+                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                        Text="{x:Bind LanguageCode}" />
+                                </controls:DockPanel>
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
                     </ComboBox>
                 </controls:SettingsCard>
 

--- a/Natsurainko.FluentLauncher/Views/ShellPage.xaml
+++ b/Natsurainko.FluentLauncher/Views/ShellPage.xaml
@@ -5,8 +5,8 @@
     xmlns:animatedvisuals="using:Microsoft.UI.Xaml.Controls.AnimatedVisuals"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:xh="using:Natsurainko.FluentLauncher.XamlHelpers"
     xmlns:searchService="using:Natsurainko.FluentLauncher.Services.UI"
+    xmlns:xh="using:Natsurainko.FluentLauncher.XamlHelpers"
     Loaded="Page_Loaded"
     SizeChanged="Page_SizeChanged"
     mc:Ignorable="d">

--- a/Natsurainko.FluentLauncher/XamlHelpers/Converters/LanguageCodeToLanguageInfoConverter.cs
+++ b/Natsurainko.FluentLauncher/XamlHelpers/Converters/LanguageCodeToLanguageInfoConverter.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.Windows.Globalization;
+using Natsurainko.FluentLauncher.Models;
+using Natsurainko.FluentLauncher.Utils;
+using Nrk.FluentCore.Authentication;
+using System;
+using System.Linq;
+
+#nullable disable
+namespace Natsurainko.FluentLauncher.XamlHelpers.Converters;
+
+internal partial class LanguageCodeToLanguageInfoConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        if (value is not string languageCode)
+            throw new ArgumentException("Value must be a string language code.");
+
+        return LocalizedStrings.SupportedLanguages.First(x => x.LanguageCode == languageCode);
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+    {
+        if (value is not LanguageInfo info)
+            throw new ArgumentException("Value must be a LanguageInfo object.");
+
+        return LocalizedStrings.SupportedLanguages.First(x => x.LanguageCode == info.LanguageCode).LanguageCode;
+    }
+}


### PR DESCRIPTION
- Set the app language using system preference on the first run.
- Store language preference using language code only.
- Disable changing option in the ComboBox by scrolling to prevent accidentally changing app language.